### PR TITLE
Fixed error while using OFFSET in query

### DIFF
--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -94,4 +94,24 @@ class QueryBuilder extends \yii\db\QueryBuilder
             . ' ADD COLUMN ' . $this->db->quoteColumnName($column) . ' '
             . $this->getColumnType($type);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function buildLimit($limit, $offset)
+    {
+        $sql = '';
+
+        if (!$this->hasLimit($limit) && $this->hasOffset($offset)) {
+            throw new Exception('Specify LIMIT value');
+        }
+
+        if ($this->hasOffset($offset)) {
+            $sql = 'LIMIT ' . $offset . ', ' . $limit;
+        } elseif ($this->hasLimit($limit)) {
+            $sql = 'LIMIT ' . $limit;
+        }
+
+        return ltrim($sql);
+    }
 }


### PR DESCRIPTION
Using an offset in the "LIMIT m OFFSET n" format causes an error:
"Syntax error: failed at position ... Expected one of: UNION ALL, Comma, BY, SETTINGS, INTO OUTFILE, FORMAT, LIMIT, token".
This is why using "LIMIT n, m" format is prefered.