### PR TITLE
Add ability to pass options to clickhouse DB client constructor

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -25,7 +25,7 @@ class Connection extends \yii\db\Connection
     public $commandClass = 'bashkarev\clickhouse\Command';
 
     /**
-     * Additional options you can pass into clickhouse client constructor
+     * Additional options you can pass to clickhouse client constructor
      *
      * @var array
      */

--- a/Connection.php
+++ b/Connection.php
@@ -25,6 +25,13 @@ class Connection extends \yii\db\Connection
     public $commandClass = 'bashkarev\clickhouse\Command';
 
     /**
+     * Additional options you can pass into clickhouse client constructor
+     *
+     * @var array
+     */
+    public $clientOptions = [];
+
+    /**
      * @var Client
      */
     private $_client;
@@ -55,12 +62,12 @@ class Connection extends \yii\db\Connection
         if ($this->_client === null) {
             $config = $this->parseDsn();
 
-            $this->_client = new Client([
+            $this->_client = new Client(array_merge([
                 'host' => $config['host'] ?? '127.0.0.1',
                 'port' => $config['port'] ?? 8123,
                 'username' => $this->username,
                 'password' => $this->password,
-            ],
+            ], $this->clientOptions),
                 array_merge([
                     'database' => $config['database'] ?? 'default',
                 ], $this->attributes ?? [])


### PR DESCRIPTION
If need connect to ClickHouse server which using SSL with self-signed CA certificate this thing will be hard to do because `Connection` class does not accept any options that can be used to change options of internal CH client using to work with CH DB.

To solve this i suggest add new param for `Connection` class that can be used to do that. I named it `$clientOptions` and it's array. You can use it to add your custom options for `ClickhouseDB` client. They will be added after standard options like host, port, username and password.

__Example:__
```php
[
   // Somewhere inside config
   'clickhouse' => [
      'class' => \bashkarev\clickhouse\Connection::class,
      'dsn' => 'host=clickhouse.localhost;port=8443;database=test',
      'username' => 'test',
      'password' => '',
      'clientOptions' => [
         'https' => true,
         'sslCA' => '/var/ssl/myRootCA.crt'
      ]
   ],
   // Here is your another config items...
]
```