### PR TITLE
Add ability to setup clickhouse client with settings

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -32,6 +32,13 @@ class Connection extends \yii\db\Connection
     public $clientOptions = [];
 
     /**
+     * Settings of the clickhouse client
+     *
+     * @var array
+     */
+    public $clientSettings = [];
+
+    /**
      * @var Client
      */
     private $_client;
@@ -70,7 +77,7 @@ class Connection extends \yii\db\Connection
             ], $this->clientOptions),
                 array_merge([
                     'database' => $config['database'] ?? 'default',
-                ], $this->attributes ?? [])
+                ], $this->attributes ?? [], $this->clientSettings)
             );
         }
     }


### PR DESCRIPTION
This PR adds `$clientSettings` attribute to the `Connection` class for ability to pass settings (if needed) to the clickhouse client